### PR TITLE
Saving card in table for compare with card dropped.-

### DIFF
--- a/client/hand/hand.go
+++ b/client/hand/hand.go
@@ -11,6 +11,7 @@ import (
 )
 
 var userCards []tools.Card
+var cardOnTable tools.Card
 
 func CreateOrUpdateHand(gui *gocui.Gui, action tools.Action) error {
 	if len(action.Cards) > 0 || len(userCards) > 0 {
@@ -19,6 +20,7 @@ func CreateOrUpdateHand(gui *gocui.Gui, action tools.Action) error {
 		if len(action.Cards) > 0 && action.Command == "" {
 			userCards = action.Cards
 			displayInitialCard(gui, action.Card)
+			_ = SaveCardOnTable(action.Card)
 		}
 
 		if action.Command == tools.TAKE && action.Card.Suit != "" {
@@ -65,12 +67,14 @@ func itsAPlayingCard(cardSent tools.Card) (interface{}, error) {
 	existingPosition := -1
 	for i, card := range userCards {
 		if cardSent.Suit == card.Suit && cardSent.Number == card.Number {
-			existingPosition = i
+			if cardSent.Suit == cardOnTable.Suit || cardSent.Number == cardOnTable.Number {
+				existingPosition = i
+			}
 		}
 	}
 
 	if existingPosition == -1 {
-		return false, errors.New("card: No posees esa carta en tu mano")
+		return false, errors.New("card: You cannot drop that card")
 	}
 
 	userCards = append(userCards[:existingPosition], userCards[existingPosition+1:]...)
@@ -112,4 +116,12 @@ func ShowHand(gui *gocui.Gui) error {
 	}
 
 	return nil
+}
+
+func SaveCardOnTable(card tools.Card) error {
+	if cardOnTable.Suit != card.Suit || cardOnTable.Number != card.Number {
+		cardOnTable = card
+		return nil
+	}
+	return errors.New("bool: Duplicated card")
 }

--- a/client/translator/translator.go
+++ b/client/translator/translator.go
@@ -115,6 +115,10 @@ func TranslateMessageFromServer(action tools.Action) (string, string, error) {
 }
 
 func showDropAction(playerId string, card tools.Card) string {
+	err := hand.SaveCardOnTable(card)
+	if err != nil {
+		return ""
+	}
 	return fmt.Sprintf("%s throws %s %s", playerId, strings.ToUpper(string(card.Suit)), strconv.Itoa(card.Number))
 }
 


### PR DESCRIPTION
- [x] Validación de carta lanzada a la mesa, sino mensaje de error.
- [x] Sino existe o sino se puede tirar(mismo palo o color) se avisa que intente nuevamente.

Capturas
|Antes de lanzar la carta erronea| Luego de lanzar la carta erronea|
|----------------|----------------|
|<img src="https://user-images.githubusercontent.com/27168934/124863868-428fc300-df8e-11eb-98e5-3ec287601c16.png" width="250">| <img src="https://user-images.githubusercontent.com/27168934/124864048-a0240f80-df8e-11eb-949c-dd4ec93ea50d.png" width="250">|